### PR TITLE
Added editorconfig to unify IDE configurations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/projects/initialization/.editorconfig
+++ b/projects/initialization/.editorconfig
@@ -1,0 +1,26 @@
+# editorconfig.org
+
+# set to true if file is present in the topmost folder of the application
+root=true
+
+[*]
+charset = utf-8
+end_of_line = lf
+# Silicon Valley's Richard may think otherwise
+indent_style = space
+# To please git. FINE. A POSIX standard.
+insert_final_newline = true
+# It's just commit noise
+trim_trailing_whitespace = true
+
+# Nodejs / Javascript / front end specific
+[*.{js,html,css,scss}]
+indent_size = 2
+
+[{**/node_modules/**,**/bower_components/**}]
+indent_style = ignore
+indent_size = ignore
+
+# Other tech stacks go here
+# Remember to remove rules not relevant to the tech stack of your project
+# Remember to also remove the comments. They have been provided only for your understanding

--- a/projects/initialization/README.md
+++ b/projects/initialization/README.md
@@ -1,0 +1,15 @@
+# Project Initialization
+
+Scenario: A new series of contests will be launched and you are working on the first contest in that series. Most likely, you are writing code from scratch. There is no code for the project currently and you have the honor of setting up the basic structure of the project.
+
+This folder deals with the expected assets to be used when a project starts from the beginning.
+
+## Editor Config
+
+Topcoder has a huge community. Developers compete around the globe. Each has their own understading of how to write code.
+
+Topcoder's success is dependent on the community coming together to deliver as much as a single developer working on the project. In order to ensure that we don't have multiple code styles on the same project, we will be using an editor configuration file that, in editorconfig.org's own words _helps developers define and maintain consistent coding styles between different editors and IDEs_
+
+Head over to [editorconfig.org](editorconfig.org) to understand how to configure your IDE and use the .editorconfig file present in this folder. Some IDEs support it automatically while others require an additional plugin to be installed.
+
+When creating a new project, include the .editorconfig file in the ROOT folder of the project. Visit the homepage of EditorConfig and set up your IDE to respect the rules defined in the file. Ensure that you start your development _after_ including the edito config file. You are expected to follow the rules defined in the file and not modify it in any manner.


### PR DESCRIPTION
Want to start making editorconfig files mandatory.

Motivation:
Developers, especially the ones with Windows OS, have different line endings. Some developers use space, some use tabs.

It's annoying when reviewing submissions, particularly F2Fs where you want to know what changes were carried out and you see git showing multiple changes being carried out, but on close observation they are just spaces being converted to tabs or vice versa and line endings changing from LF to CRLF or vice versa.

Unify all developers' IDEs.

Relevant Code Scorecard under which defying the editor configurations can be considered -
Section 1.2.1: Does the submission follow standard coding best practices?
